### PR TITLE
Upgraded embulk version to v0.7.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ configurations {
 version = "0.1.0"
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.4.2"
-    provided "org.embulk:embulk-core:0.4.2"
+    compile  "org.embulk:embulk-core:0.7.4"
+    provided "org.embulk:embulk-core:0.7.4"
 
     compile "com.twitter:parquet-hadoop:1.5.0"
     compile "org.apache.hadoop:hadoop-client:2.6.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 16 18:53:39 JST 2015
+#Tue Aug 11 00:26:20 PDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-bin.zip

--- a/src/main/java/org/embulk/output/ParquetOutputPlugin.java
+++ b/src/main/java/org/embulk/output/ParquetOutputPlugin.java
@@ -11,7 +11,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
-import org.embulk.config.CommitReport;
+import org.embulk.config.TaskReport;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
@@ -83,7 +83,7 @@ public class ParquetOutputPlugin
 
     public void cleanup(TaskSource taskSource,
             Schema schema, int processorCount,
-            List<CommitReport> successCommitReports)
+            List<TaskReport> successTaskReports)
     {
         //TODO
     }
@@ -191,8 +191,8 @@ public class ParquetOutputPlugin
         }
 
         @Override
-        public CommitReport commit() {
-            return Exec.newCommitReport();
+        public TaskReport commit() {
+            return Exec.newTaskReport();
             //TODO
         }
     }


### PR DESCRIPTION
Embulk 0.7 does not have backward compatiblity.
So, let's upgrade to Embulk 0.7!
