### PR TITLE
Add option addUTF8

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 http://www.embulk.org/docs/built-in.html#csv-formatter-plugin).
 - **extra_configurations**: Add extra entries to Configuration which will be passed to ParquetWriter
 - **overwrite**: Overwrite if output files already exist. (default: fail if files exist)
+- **addUTF8**: If true, string and timestamp columns are stored with OriginalType.UTF8 (boolean, default false) 
 
 ## Example
 

--- a/src/main/java/org/embulk/output/EmbulkWriteSupport.java
+++ b/src/main/java/org/embulk/output/EmbulkWriteSupport.java
@@ -5,6 +5,7 @@ import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.io.api.RecordConsumer;
 import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type;
@@ -165,7 +166,7 @@ public class EmbulkWriteSupport
         @Override
         public void stringColumn(Column column)
         {
-            fields.add(new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.BINARY, column.getName()));
+            fields.add(new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.BINARY, column.getName(), OriginalType.UTF8));
         }
 
         @Override

--- a/src/main/java/org/embulk/output/EmbulkWriterBuilder.java
+++ b/src/main/java/org/embulk/output/EmbulkWriterBuilder.java
@@ -13,12 +13,14 @@ public class EmbulkWriterBuilder
 {
     final Schema schema;
     final TimestampFormatter[] timestampFormatters;
+    final boolean addUTF8;
 
-    public EmbulkWriterBuilder(Path file, Schema schema, TimestampFormatter[] timestampFormatters)
+    public EmbulkWriterBuilder(Path file, Schema schema, TimestampFormatter[] timestampFormatters, boolean addUTF8)
     {
         super(file);
         this.schema = schema;
         this.timestampFormatters = timestampFormatters;
+        this.addUTF8 = addUTF8;
     }
 
     @Override
@@ -30,6 +32,6 @@ public class EmbulkWriterBuilder
     @Override
     protected WriteSupport<PageReader> getWriteSupport(Configuration conf)
     {
-        return new EmbulkWriteSupport(schema, timestampFormatters);
+        return new EmbulkWriteSupport(schema, timestampFormatters, addUTF8);
     }
 }

--- a/src/main/java/org/embulk/output/ParquetOutputPlugin.java
+++ b/src/main/java/org/embulk/output/ParquetOutputPlugin.java
@@ -71,6 +71,10 @@ public class ParquetOutputPlugin
         @Config("overwrite")
         @ConfigDefault("false")
         boolean getOverwrite();
+
+        @Config("addUTF8")
+        @ConfigDefault("false")
+        boolean getAddUTF8();
     }
 
     public interface TimestampColumnOption
@@ -125,6 +129,7 @@ public class ParquetOutputPlugin
     private ParquetWriter<PageReader> createWriter(PluginTask task, Schema schema, int processorIndex)
     {
         final TimestampFormatter[] timestampFormatters = Timestamps.newTimestampColumnFormatters(task, schema, task.getColumnOptions());
+        final boolean addUTF8 = task.getAddUTF8();
 
         final Path path = new Path(buildPath(task, processorIndex));
         final CompressionCodecName codec = CompressionCodecName.valueOf(task.getCompressionCodec());
@@ -135,7 +140,7 @@ public class ParquetOutputPlugin
 
         ParquetWriter<PageReader> writer = null;
         try {
-            EmbulkWriterBuilder builder = new EmbulkWriterBuilder(path, schema, timestampFormatters)
+            EmbulkWriterBuilder builder = new EmbulkWriterBuilder(path, schema, timestampFormatters, addUTF8)
                     .withCompressionCodec(codec)
                     .withRowGroupSize(blockSize)
                     .withPageSize(pageSize)


### PR DESCRIPTION
I would like to add an option 'addUTF8'.
If I tried to read the parquet files generated by this plugin from Apache Spark 2.1.0, string and timestamp columns are converted to binary type in spark and it is inconvenient.
If this option set to true, string and timestamp columns are stored with OriginalType.UTF8 and spark can load them as string column.
Default of this option is false, So I believe this option will not break compatibility.
