### PR TITLE
Implements config_files option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - **default_timestamp_format**: Format of timestamp columns. This can be overwritten for each column using column_options
 - **column_options**: Specify timezone and timestamp format for each column. Format of this option is the same as the official csv formatter. See [document](
 http://www.embulk.org/docs/built-in.html#csv-formatter-plugin).
+- **config_files**: List of path to Hadoop's configuration files (array of string, default: `[]`)
 - **extra_configurations**: Add extra entries to Configuration which will be passed to ParquetWriter
 - **overwrite**: Overwrite if output files already exist. (default: fail if files exist)
 

--- a/src/test/java/org/embulk/output/ParquetOutputPluginTest.java
+++ b/src/test/java/org/embulk/output/ParquetOutputPluginTest.java
@@ -10,6 +10,8 @@ import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -62,9 +64,9 @@ public class ParquetOutputPluginTest
         assertEquals("bar", extra.get("foo"));
 
         ParquetOutputPlugin plugin = new ParquetOutputPlugin();
-        Method method = ParquetOutputPlugin.class.getDeclaredMethod("createConfiguration", Map.class);
+        Method method = ParquetOutputPlugin.class.getDeclaredMethod("createConfiguration", Map.class, List.class);
         method.setAccessible(true);
-        Configuration conf = (Configuration) method.invoke(plugin, extra);
+        Configuration conf = (Configuration) method.invoke(plugin, extra, new ArrayList<String>());
         assertEquals("bar", conf.get("foo"));
     }
 }


### PR DESCRIPTION
I would like to add an option **config_files** which read hadoop configuration files.
This option is implemented in other hadoop related plugins such as embulk-input-parquet_hadoop, embulk-output-hdfs. So I believe It is also useful in this plugin.
