### PR TITLE
Set class loader to Plugin's class loader.

### DIFF
--- a/src/main/java/org/embulk/output/ParquetOutputPlugin.java
+++ b/src/main/java/org/embulk/output/ParquetOutputPlugin.java
@@ -23,6 +23,7 @@ import org.embulk.spi.Schema;
 import org.embulk.spi.TransactionalPageOutput;
 import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.util.Timestamps;
+import org.embulk.output.parquet.ClassLoaderSwap;
 
 import java.io.IOException;
 import java.util.List;
@@ -86,7 +87,9 @@ public class ParquetOutputPlugin
 
         //TODO
 
-        control.run(task.dump());
+        try (ClassLoaderSwap clswp = new ClassLoaderSwap(this.getClass())) {
+            control.run(task.dump());
+        }
         return Exec.newConfigDiff();
     }
 

--- a/src/main/java/org/embulk/output/parquet/ClassLoaderSwap.java
+++ b/src/main/java/org/embulk/output/parquet/ClassLoaderSwap.java
@@ -1,0 +1,25 @@
+package org.embulk.output.parquet;
+
+/**
+ * This class is based on embulk-input-parquet_hadoop PluginClassLoaderScope.java
+ */
+public class ClassLoaderSwap<T> implements AutoCloseable
+{
+    private final ClassLoader pluginClassLoader;
+    private final ClassLoader orgClassLoader;
+    private final Thread curThread;
+
+    public ClassLoaderSwap(Class<T> pluginClass)
+    {
+        this.curThread = Thread.currentThread();
+        this.pluginClassLoader = pluginClass.getClassLoader();
+        this.orgClassLoader = curThread.getContextClassLoader();
+        curThread.setContextClassLoader(pluginClassLoader);
+    }
+
+    @Override
+    public void close()
+    {
+        curThread.setContextClassLoader(orgClassLoader);
+    }
+}


### PR DESCRIPTION
To support GCS (Google Cloud Storage), I would like to set class loader to PluginClassLoader.
I referenced embulk-input-parquet_hadoop , it works with gcs-hadoop connector.